### PR TITLE
Handle file permission denied

### DIFF
--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -99,8 +99,14 @@ class AddCommand extends Command
             return;
         }
 
-        file_put_contents($filename, $hookContents);
-        chmod($filename, 0755);
+        if (false === file_put_contents($filename, $hookContents)) {
+            $this->error("[{$hook}] could not be written");
+            return;
+        }
+        if (false === chmod($filename, 0755)) {
+            $this->error("[{$hook}] could not set write permissions");
+            return;
+        }
 
         $operation = $exists ? 'Updated' : 'Added';
         $this->info("{$operation} [{$hook}] hook");

--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -86,17 +86,20 @@ class AddCommand extends Command
         $contents = Hook::getHookContents($composerDir, $contents, $hook);
         $hookContents = $shebang . $contents . PHP_EOL;
 
-        if (! $this->force && $exists) {
+        if ($exists) {
+            // do not continue if the content is already "up to date", forced or not
             $actualContents = file_get_contents($filename);
-
             if ($actualContents === $hookContents) {
                 $this->debug("[{$hook}] is up to date");
                 $this->upToDateHooks[] = $hook;
                 return;
             }
 
-            $this->debug("[{$hook}] already exists");
-            return;
+            // only continue if forced
+            if (!$this->force) {
+                $this->debug("[{$hook}] already exists");
+                return;
+            }
         }
 
         if (false === file_put_contents($filename, $hookContents)) {


### PR DESCRIPTION
* check if file could not be written or changed, and show an appropiate error message
* do not continue adding hooks if the content is already "up to date" , forced or not
* only continue adding hooks if it exists and forced